### PR TITLE
Enable live-reload when on welcome page.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,15 @@ var fs = require('fs');
 var path = require('path');
 var walkSync = require('walk-sync');
 
+function getWelcomePageHTML(baseURL) {
+  var lodash = require('lodash');
+  var fileName = path.join(__dirname, 'vendor', 'welcome.html');
+  var contents = fs.readFileSync(fileName, { encoding: 'utf8' });
+  var compiled = lodash.template(contents);
+
+  return compiled({ baseURL: baseURL });
+}
+
 module.exports = {
   name: 'ember-welcome-page',
 
@@ -25,6 +34,8 @@ module.exports = {
     this.ui.writeInfoLine("\nJust getting started with Ember? Please visit http://localhost:" + options.port + "/ember-getting-started to get going\n");
     var _this = this;
 
+    var welcomePageHTML = getWelcomePageHTML(options.baseURL);
+
     app.get('/ember-getting-started-image.png', function (req, res, next) {
       res.sendFile(__dirname + '/vendor/construction.png', options, function (err) {
         if (err) {
@@ -32,22 +43,15 @@ module.exports = {
         }
       });
     });
+
     app.get('/ember-getting-started', function (req, res, next) {
-      res.sendFile(__dirname + '/vendor/welcome.html', options, function (err) {
-        if (err) {
-          res.status(err.status).end();
-        }
-      });
+      res.send(welcomePageHTML);
     });
 
     // we'll assume we're running '/' but then bail if we aren't supposed to be overriding
-    app.get('/', function(req, res, next) {
+    app.get(options.baseURL, function(req, res, next) {
       if (_this.shouldOverride(_this.jsExt, _this.templateExt, _this.app.project.root)) {
-        res.sendFile(__dirname + '/vendor/welcome.html', options, function (err) {
-          if (err) {
-            res.status(err.status).end();
-          }
-        });
+        res.send(welcomePageHTML);
       } else {
         next();
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "exists-sync": "0.0.3",
+    "lodash": "^4.7.0",
     "walk-sync": "^0.2.6"
   },
   "ember-addon": {

--- a/vendor/welcome.html
+++ b/vendor/welcome.html
@@ -68,6 +68,8 @@
       margin: 0 0.1em;
     }
   </style>
+
+  <script src="<%= baseURL %>ember-cli-live-reload.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
This ensures that the live-reload script that is normally injected by ember-cli-inject-live-reload is loaded into the welcome page itself (so when files are added/changed in the repo the welcome page will remove itself).

Fixes https://github.com/ember-cli/ember-welcome-page/issues/18.