### PR TITLE
Change Ember npm package name to `ember-source`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = {
     this.app = app;
 
     var checker = new VersionChecker(this);
-    this.guidesVersion = this.massageVersionNumber(checker.for('ember', 'bower').version || checker.for('ember-core', 'npm').version);
+    this.guidesVersion = this.massageVersionNumber(checker.for('ember', 'bower').version || checker.for('ember-source', 'npm').version);
 
     this.jsExt = this.app.registry.extensionsForType('js');
     this.templateExt = this.app.registry.extensionsForType('template');


### PR DESCRIPTION
This PR changes the expected npm package name to `ember-source`, as per ember-cli/ember-cli#6324