### PR TITLE
Do not use an absolute path for the image

### DIFF
--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -1,7 +1,7 @@
 <div id="ember-welcome-page-id-selector" data-ember-version="{{emberVersion}}">
   <div class="columns">
     <div class="tomster">
-      <img src="/ember-welcome-page/images/construction.png" alt="Under construction">
+      <img src="ember-welcome-page/images/construction.png" alt="Under construction">
     </div>
     <div class="welcome">
       <h2 id="title">Congratulations, you made it!</h2>


### PR DESCRIPTION
Using an absolute path for the image break the image when the Ember `rootURL` is not `/`.