### PR TITLE
Update to Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/ember-cli/ember-welcome-page",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "David Baker <acorncom@gmail.com>",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "ember-cli": "2.8.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^2.1.0",
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.0.0-beta.9",
     "ember-cli-htmlbars": "^1.0.3"
   },
   "ember-addon": {


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.

ember-cli-babel@6 requires node 4+, so this also bumps the minimum engine version.

This should be published as 3.0.0.