### PR TITLE
Allow for linking alpha, beta, master to current

### DIFF
--- a/addon/components/welcome-page.js
+++ b/addon/components/welcome-page.js
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/application';
 import { VERSION } from '@ember/version';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import Component from '@ember/component';
 import layout from '../templates/components/welcome-page';
 import { gte } from 'ember-compatibility-helpers';
@@ -8,10 +8,20 @@ import { gte } from 'ember-compatibility-helpers';
 export default Component.extend({
   layout,
 
-  emberVersion: computed(function() {
-    let [ major, minor ] = VERSION.split(".");
+  isCurrent: computed(function() {
+    let displayCurrent = false;
+    let version = VERSION;
+    let patch = version.split(".")[2];
 
-    return `${major}.${minor}.0`;
+    if (version === 'master') {
+      displayCurrent = true;
+    } else if (patch.match('alpha')) {
+      displayCurrent = true;
+    } else if (patch.match('beta')) {
+      displayCurrent = true;
+    }
+
+    return displayCurrent;
   }),
 
   canAngleBracket: computed(function() {
@@ -31,6 +41,17 @@ export default Component.extend({
       return config.class.rootURL;
     } else {
       return '/';
+    }
+  }),
+
+  emberVersion: computed('isCurrent', function() {
+    let isCurrent = get(this, 'isCurrent');
+
+    if (isCurrent) {
+      return 'current';
+    } else {
+      let [ major, minor ] = VERSION.split(".");
+      return `${major}.${minor}.0`;
     }
   })
 });

--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -9,8 +9,8 @@
       <p>You&rsquo;ve officially spun up your very first Ember app :-)</p>
       <p>You&rsquo;ve got one more decision to make: what do you want to do next? We&rsquo;d suggest one of the following to help you get going:</p>
       <ol>
-        <li><a href="https://guides.emberjs.com/v{{emberVersion}}/getting-started/quick-start/">Quick Start</a> - a quick introduction to how Ember works. Learn about defining your first route, writing a UI component and deploying your application.</li>
-        <li><a href="https://guides.emberjs.com/v{{emberVersion}}/tutorial/ember-cli/">Ember Guides</a> - this is our more thorough, hands-on intro to Ember. Your crash course in Ember philosophy, background and some in-depth discussion of how things work (and why they work the way they do).</li>
+        <li><a href="https://guides.emberjs.com/{{if isCurrent '' 'v'}}{{emberVersion}}/getting-started/quick-start/">Quick Start</a> - a quick introduction to how Ember works. Learn about defining your first route, writing a UI component and deploying your application.</li>
+        <li><a href="https://guides.emberjs.com/{{if isCurrent '' 'v'}}{{emberVersion}}/tutorial/ember-cli/">Ember Guides</a> - this is our more thorough, hands-on intro to Ember. Your crash course in Ember philosophy, background and some in-depth discussion of how things work (and why they work the way they do).</li>
       </ol>
       <p>If you run into problems, you can check <a href="http://stackoverflow.com/questions/tagged/ember.js">Stack Overflow</a> or <a href="http://discuss.emberjs.com/">our forums</a>  for ideas and answers—someone&rsquo;s probably been through the same thing and already posted an answer.  If not, you can post your <strong>own</strong> question. People love to help new Ember developers get started, and our <a href="https://emberjs.com/community/">Ember Community</a> is incredibly supportive.</p>
     </div>

--- a/tests/integration/components/welcome-page-test.js
+++ b/tests/integration/components/welcome-page-test.js
@@ -2,8 +2,13 @@ import { VERSION } from '@ember/version';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
+const emberVersion = VERSION;
+
 moduleForComponent('welcome-page', 'Integration | Component | welcome page', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    VERSION = emberVersion;
+  }
 });
 
 test('it renders', function(assert) {
@@ -18,4 +23,37 @@ test('it renders', function(assert) {
   assert.equal(emberMajor, welcomeMajor, "Major segment of version should match.");
   assert.equal(emberMinor, welcomeMinor, "Minor segment of version should match.");
   assert.equal("0", welcomePatch, "Patch segment of version should be 0.");
+});
+
+test('it links to "/current" for alpha versions', function(assert) {
+  // Set the version property
+  VERSION = '2.15.0-alpha.1';
+
+  this.render(hbs`{{welcome-page}}`);
+
+  let versionText = this.$('[data-ember-version]').data('ember-version');
+
+  assert.equal(versionText, 'current', "Version text should be set to 'current' when an alpha version is used.");
+});
+
+test('it links to "/current" for beta versions', function(assert) {
+  // Set the version property
+  VERSION = '2.15.0-beta.1';
+
+  this.render(hbs`{{welcome-page}}`);
+
+  let versionText = this.$('[data-ember-version]').data('ember-version');
+
+  assert.equal(versionText, 'current', "Version text should be set to 'current' when a beta version is used.");
+});
+
+test('it links to "/current" for master', function(assert) {
+  // Set the version property
+  VERSION = 'master';
+
+  this.render(hbs`{{welcome-page}}`);
+
+  let versionText = this.$('[data-ember-version]').data('ember-version');
+
+  assert.equal(versionText, 'current', "Version text should be set to 'current' when master is used.");
 });

--- a/tests/integration/components/welcome-page-test.js
+++ b/tests/integration/components/welcome-page-test.js
@@ -11,9 +11,10 @@ moduleForComponent('welcome-page', 'Integration | Component | welcome page', {
   }
 });
 
-test('it renders', function(assert) {
+test('it links to version for release version', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
+  VERSION = '3.1.5';
 
   this.render(hbs`{{welcome-page}}`);
 


### PR DESCRIPTION
The idea with this is to determine if the version of Ember being used is "current" so that the link to the documentation can use the `/current` url instead of the `v<major>.<minor>.0` format. The current check is very basic and is just looking to see if the patch part of the version string contains "alpha" or "beta" or if the version string is "master".

I tested this on a fresh install of Ember v2.15.0-beta.1 and it linked to current, which redirects to the v2.14.0 documentation.

I'm open to suggestions on improving the current logic, but thought it was a good first step.

Fixes #72 