### PR TITLE
Add a list of apps' dependencies to the addon

### DIFF
--- a/addon/components/welcome-page.js
+++ b/addon/components/welcome-page.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 import layout from '../templates/components/welcome-page';
+import AppDependencyDescriptors from '../-app-dependency-descriptors';
 
 export default Ember.Component.extend({
   layout,
+
+  dependencies: AppDependencyDescriptors,
 
   emberVersion: Ember.computed(function() {
     let [ major, minor ] = Ember.VERSION.split(".");

--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -1,4 +1,27 @@
 <div id="ember-welcome-page-id-selector" data-ember-version="{{emberVersion}}">
+  {{#if showDependencies}}
+    <div class="dependencies">
+      <button class="dependency-button" {{action (mut showDependencies) false}}>Hide Dependencies</button>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Version</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each dependencies as |dependency|}}
+            <tr>
+              <td><a href={{dependency.href}}>{{dependency.name}}</a></td>
+              <td><code>{{dependency.version}}</code></td>
+              <td>{{dependency.description}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
+  {{else}}
   <div class="columns">
     <div class="tomster">
       <img src="ember-welcome-page/images/construction.png" alt="Under construction">
@@ -13,7 +36,9 @@
         <li><a href="https://guides.emberjs.com/v{{emberVersion}}/tutorial/ember-cli/">Ember Guides</a> - this is our more thorough, hands-on intro to Ember. Your crash course in Ember philosophy, background and some in-depth discussion of how things work (and why they work the way they do).</li>
       </ol>
       <p>If you run into problems, you can check <a href="http://stackoverflow.com/questions/tagged/ember.js">Stack Overflow</a> or <a href="http://discuss.emberjs.com/">our forums</a>  for ideas and answers—someone&rsquo;s probably been through the same thing and already posted an answer.  If not, you can post your <strong>own</strong> question. People love to help new Ember developers get started, and our <a href="https://emberjs.com/community/">Ember Community</a> is incredibly supportive.</p>
+      <button class="dependency-button" {{action (mut showDependencies) true}}>Show Dependencies</button>
     </div>
   </div>
+  {{/if}}
     <p class="postscript">To remove this welcome message, remove the <code>\{{welcome-page}}</code> component from your <code>application.hbs</code> file.<br>You'll see this page update soon after!</p>
 </div>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 /* eslint-env node */
 'use strict';
 
+var path = require('path');
+var writeFile = require('broccoli-file-creator');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-welcome-page',
 
@@ -26,7 +30,19 @@ module.exports = {
 
     var tree = this._super.treeForAddon.apply(this, arguments);
 
-    return tree;
+    var appDependencyDescriptorsJson = this._buildAppDependencyTree();
+
+    var appDependencyDescriptorsContent
+      = "define('ember-welcome-page/-app-dependency-descriptors', ['exports'], function(exports) {\n"
+      + "  exports.default = " + JSON.stringify(appDependencyDescriptorsJson) + ";\n"
+      + '});';
+
+    var appDependencyDescriptorsFile = writeFile(
+      '/addon/-app-dependency-descriptors.js',
+      appDependencyDescriptorsContent
+    );
+
+    return new MergeTrees([tree, appDependencyDescriptorsFile]);
   },
 
   treeForApp: function() {
@@ -39,5 +55,35 @@ module.exports = {
 
   _isDisabled: function() {
     return process.env.EMBER_ENV === 'production' && !this._welcomeConfig.enabled;
+  },
+
+  _buildAppDependencyTree() {
+    var _this = this;
+    var appDependencyList = this._findAppDependencies();
+    return appDependencyList.map(function(nodeModule) {
+      return _this._buildNodeModuleDescriptorObject(nodeModule);
+    });
+  },
+
+  _findAppDependencies() {
+    var appPkg = require(path.join(this.project.root, 'package.json'));
+    var dependencies = Object.keys(appPkg.dependencies || {});
+    var devDependencies = Object.keys(appPkg.devDependencies || {});
+    var optionalDependencies = Object.keys(appPkg.optionalDependencies || {});
+    return dependencies.concat(devDependencies, optionalDependencies);
+  },
+
+  _buildNodeModuleDescriptorObject(nodeModule) {
+    var pkg = require(path.join(this.project.root, 'node_modules', nodeModule, 'package.json'));
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      href: this._buildUrl(pkg)
+    };
+  },
+
+  _buildUrl(pkg) {
+    return 'https://www.npmjs.com/package/' + pkg.name;
   }
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^3.0.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3"
   },

--- a/vendor/welcome-page.css
+++ b/vendor/welcome-page.css
@@ -65,6 +65,21 @@
   padding: 0.2em 0.5em;
   margin: 0 0.1em;
 }
+#ember-welcome-page-id-selector .dependencies-button {
+  text-align: center;
+  font-size: 14px;
+  margin: 0 auto;
+}
+#ember-welcome-page-id-selector .dependencies {
+  clear: both;
+  width: 100%;
+  padding-top: 3em;
+  font-size: 14px;
+  line-height: 2;
+}
+#ember-welcome-page-id-selector .dependencies table {
+  margin: 0 auto;
+}
 @media (max-width: 700px) {
   #ember-welcome-page-id-selector {
     padding: 1em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,13 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2, broccoli-debug@^0.6.3:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-file-creator@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1094,6 +1101,13 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
+broccoli-merge-trees@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz#92f4e1fb9a791ea986245a7077f35cc648dab097"
@@ -1119,7 +1133,7 @@ broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6, broccoli-p
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -1325,6 +1339,10 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
+
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -2572,6 +2590,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2813,14 +2841,14 @@ heimdalljs-graph@^0.3.1:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz#0bd75797beeaa20b0ed59017aed3b2d95312acee"
 
-heimdalljs-logger@^0.1.7:
+heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz#d76ada4e45b7bb6f786fc9c010a68eb2e2faf176"
   dependencies:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -3703,6 +3731,13 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -4427,7 +4462,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
This is in response to [this discussion][1] where users wanted an easy place to see all the dependencies a new app has built in with a description and a link to the READMEs to know why they are needed or optional.

A suggestion to use the welcome-page as the source for this would allow us to provide the information easily while avoiding the need to maintain any curated list ourselves.

![welcome-page-pr](https://user-images.githubusercontent.com/70075/41004748-fb9841c6-68e8-11e8-8c2d-c3408e2621b3.gif)

[1]: https://discuss.emberjs.com/t/too-many-dependencies-in-package-json/14831/6