### PR TITLE
Support Angle Bracket syntax and MU layout

### DIFF
--- a/addon/components/welcome-page.js
+++ b/addon/components/welcome-page.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/welcome-page';
+import { gte } from 'ember-compatibility-helpers';
 
 export default Ember.Component.extend({
   layout,
@@ -11,8 +12,7 @@ export default Ember.Component.extend({
   }),
 
   canAngleBracket: Ember.computed(function() {
-    let [ major, minor ] = Ember.VERSION.split(".");
-    return parseFloat(`${major}.${minor}`) >= 3.4;
+    return gte('3.4.0');
   }),
 
   isModuleUnification: Ember.computed(function() {

--- a/addon/components/welcome-page.js
+++ b/addon/components/welcome-page.js
@@ -8,5 +8,16 @@ export default Ember.Component.extend({
     let [ major, minor ] = Ember.VERSION.split(".");
 
     return `${major}.${minor}.0`;
+  }),
+
+  canAngleBracket: Ember.computed(function() {
+    let [ major, minor ] = Ember.VERSION.split(".");
+    return parseFloat(`${major}.${minor}`) >= 3.4;
+  }),
+
+  isModuleUnification: Ember.computed(function() {
+    const config = Ember.getOwner(this).resolveRegistration('config:environment');
+
+    return config && config.isModuleUnification;
   })
 });

--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -15,5 +15,22 @@
       <p>If you run into problems, you can check <a href="http://stackoverflow.com/questions/tagged/ember.js">Stack Overflow</a> or <a href="http://discuss.emberjs.com/">our forums</a>  for ideas and answers—someone&rsquo;s probably been through the same thing and already posted an answer.  If not, you can post your <strong>own</strong> question. People love to help new Ember developers get started, and our <a href="https://emberjs.com/community/">Ember Community</a> is incredibly supportive.</p>
     </div>
   </div>
-    <p class="postscript">To remove this welcome message, remove the <code>\{{welcome-page}}</code> component from your <code>application.hbs</code> file.<br>You'll see this page update soon after!</p>
+  <p class="postscript">To remove this welcome message, remove the
+    <code>
+      {{#if canAngleBracket}}
+        &lt;WelcomePage /&gt;
+      {{else}}
+        \{{welcome-page}}
+      {{/if}}
+    </code>
+    component from your
+    <code>
+      {{#if isModuleUnification}}
+        ui/routes/application/template.hbs
+      {{else}}
+        application.hbs
+      {{/if}}
+    </code>
+     file.<br>You'll see this page update soon after!
+  </p>
 </div>

--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -26,9 +26,9 @@
     component from your
     <code>
       {{#if isModuleUnification}}
-        ui/routes/application/template.hbs
+        src/ui/routes/application/template.hbs
       {{else}}
-        application.hbs
+        app/templates/application.hbs
       {{/if}}
     </code>
      file.<br>You'll see this page update soon after!

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-welcome-page',
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     this._welcomeConfig = app.options['ember-welcome-page'] || {};
 

--- a/index.js
+++ b/index.js
@@ -6,11 +6,22 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
+
     this._welcomeConfig = app.options['ember-welcome-page'] || {};
 
     if (this._isDisabled()) { return; }
 
     app.import('vendor/welcome-page.css');
+  },
+
+  config: function() {
+
+    const project = this.app && this.app.project;
+    if (project) {
+      return {
+        isModuleUnification: project.isModuleUnification && project.isModuleUnification()
+      };
+    }
   },
 
   treeForPublic: function() {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
 
   config: function() {
 
-    const project = this.app && this.app.project;
+    const project = this.project;
     if (project) {
       return {
         isModuleUnification: project.isModuleUnification && project.isModuleUnification()

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^7.4.1",
-    "ember-cli-htmlbars": "^3.0.1"
+    "ember-cli-htmlbars": "^3.0.1",
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {
     "ember-cli": "~3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.2.0-beta.6:
+babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
   dependencies:
@@ -2648,6 +2648,14 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
+  integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.7.1.tgz#f307bcd68aaf083612717ab32133120272d89170"
@@ -2742,6 +2750,15 @@ ember-cli@~3.7.1:
     walk-sync "^1.0.0"
     watch-detector "^0.1.0"
     yam "^1.0.0"
+
+ember-compatibility-helpers@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
+  integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
 
 ember-load-initializers@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It changes the component copies:

`{{welcome-page}}` for Ember < 3.4
`<WelcomePage />` for Ember >= 3.4

and show the corrent location depending if it is Classic or MU layout.

Discussed at https://github.com/ember-cli/ember-cli/pull/8383, we should also:

- bump version
- update the ember-cli blueprints

