### PR TITLE
Make construction tomster show for non-application routes

### DIFF
--- a/addon/components/welcome-page.js
+++ b/addon/components/welcome-page.js
@@ -19,5 +19,15 @@ export default Ember.Component.extend({
     const config = Ember.getOwner(this).resolveRegistration('config:environment');
 
     return config && config.isModuleUnification;
+  }),
+
+  rootURL: Ember.computed(function() {
+    let config = Ember.getOwner(this).factoryFor('config:environment');
+
+    if (config) {
+      return config.class.rootURL;
+    } else {
+      return '/';
+    }
   })
 });

--- a/addon/templates/components/welcome-page.hbs
+++ b/addon/templates/components/welcome-page.hbs
@@ -1,7 +1,7 @@
 <div id="ember-welcome-page-id-selector" data-ember-version="{{emberVersion}}">
   <div class="columns">
     <div class="tomster">
-      <img src="ember-welcome-page/images/construction.png" alt="Under construction">
+      <img src="{{rootURL}}ember-welcome-page/images/construction.png" alt="Under construction">
     </div>
     <div class="welcome">
       <h2 id="title">Congratulations, you made it!</h2>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "broccoli-funnel": "^2.0.2",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
-    "ember-compatibility-helpers": "^1.2.0"
+    "ember-compatibility-helpers": "^1.2.0",
+    "ember-factory-for-polyfill": "^1.3.1"
   },
   "devDependencies": {
     "ember-cli": "~3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,6 +3005,13 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-factory-for-polyfill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
+  integrity sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+
 ember-load-initializers@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.0.0.tgz#d4b3108dd14edb0f9dc3735553cc96dadd8a80cb"


### PR DESCRIPTION

Adds a rootURL to the construction tomster image so that it works when navigating away from the application route.

Closes #82.