### PR TITLE
Remove appearance of trailing whitespace in code blocks

### DIFF
--- a/vendor/welcome-page.css
+++ b/vendor/welcome-page.css
@@ -58,11 +58,12 @@
   line-height: 2;
 }
 #ember-welcome-page-id-selector .postscript code {
+  display: inline-block;
   background-color: #F8E7CF;
   border-radius: 3px;
   font-family: Menlo, Courier, monospace;
   font-size: 0.9em;
-  padding: 0.2em 0.5em;
+  padding: 0 0.5em;
   margin: 0 0.1em;
 }
 @media (max-width: 700px) {


### PR DESCRIPTION
I admit this is a minor issue, but given this component is loaded with every new project and is one of the first things a user sees, I think it's worth fixing.

Here's the current variant:
![Screen Shot 2019-09-09 at 2 42 56 PM](https://user-images.githubusercontent.com/366944/64536587-a822b200-d319-11e9-9e6c-b68bb786bf42.png)
You can see that the highlighted background isn't balanced: there's more empty space to the right of the code block.

After a small CSS tweak:
![Screen Shot 2019-09-09 at 2 42 01 PM](https://user-images.githubusercontent.com/366944/64536667-c5578080-d319-11e9-8ddc-cffae38a77e5.png)
