### PR TITLE
Introduced Glint to ember-welcome-page

### DIFF
--- a/ember-welcome-page/package.json
+++ b/ember-welcome-page/package.json
@@ -39,7 +39,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "glint",
     "prepack": "rollup --config",
     "start": "rollup --config --watch",
     "test": "echo \"A v2 addon does not have tests, run tests in test-app\""
@@ -54,6 +54,9 @@
     "@babel/plugin-proposal-decorators": "^7.20.5",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
+    "@glint/core": "^1.0.0-beta.2",
+    "@glint/environment-ember-loose": "^1.0.0-beta.2",
+    "@glint/template": "^1.0.0-beta.2",
     "@tsconfig/ember": "^1.1.0",
     "@types/ember__application": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^5.47.0",

--- a/ember-welcome-page/src/components/welcome-page.ts
+++ b/ember-welcome-page/src/components/welcome-page.ts
@@ -10,7 +10,10 @@ function isLatestVersion(): boolean {
   return !stableRegex.test(VERSION as string);
 }
 
-export default class WelcomePageComponent extends Component {
+/* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+interface WelcomePageComponentSignature {}
+
+export default class WelcomePageComponent extends Component<WelcomePageComponentSignature> {
   get rootURL(): string {
     const config = getOwner(this).factoryFor('config:environment');
 

--- a/ember-welcome-page/src/template-registry.ts
+++ b/ember-welcome-page/src/template-registry.ts
@@ -1,0 +1,11 @@
+// Easily allow apps, which are not yet using strict mode templates, to consume your Glint types, by importing this file.
+// Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
+// See https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons
+
+// import type MyComponent from './components/my-component';
+
+// Remove this once entries have been added! 👇
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export default interface Registry {
+  // MyComponent: typeof MyComponent
+}

--- a/ember-welcome-page/src/template-registry.ts
+++ b/ember-welcome-page/src/template-registry.ts
@@ -1,11 +1,6 @@
-// Easily allow apps, which are not yet using strict mode templates, to consume your Glint types, by importing this file.
-// Add all your components, helpers and modifiers to the template registry here, so apps don't have to do this.
-// See https://typed-ember.gitbook.io/glint/using-glint/ember/authoring-addons
+import type WelcomePageComponent from './components/welcome-page';
 
-// import type MyComponent from './components/my-component';
-
-// Remove this once entries have been added! 👇
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export default interface Registry {
-  // MyComponent: typeof MyComponent
+export default interface EmberWelcomePageRegistry {
+  WelcomePage: typeof WelcomePageComponent;
+  'welcome-page': typeof WelcomePageComponent;
 }

--- a/ember-welcome-page/tsconfig.json
+++ b/ember-welcome-page/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*",
+    "unpublished-development-types/**/*"
+  ],
+  "glint": {
+    "environment": "ember-loose"
+  }
 }

--- a/ember-welcome-page/unpublished-development-types/index.d.ts
+++ b/ember-welcome-page/unpublished-development-types/index.d.ts
@@ -1,0 +1,13 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
+
+import '@glint/environment-ember-loose';
+
+declare module '@glint/environment-ember-loose/registry' {
+  // Remove this once entries have been added! 👇
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export default interface Registry {
+    // Add any registry entries from other addons here that your addon itself uses (in non-strict mode templates)
+    // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,6 +1312,30 @@
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
+"@glint/core@^1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@glint/core/-/core-1.0.0-beta.2.tgz#68682d4663e2ae3eebfd0682b9f9505e4a33bb6f"
+  integrity sha512-LmQ7I0BXGzL5FhtaXXUCNUfGnqK6s+WKbcT0VcL3vxfMYW4btCzcWMOrBOhczI1+yYbPdVe++Rb+l0ovWURPzQ==
+  dependencies:
+    "@glimmer/syntax" "^0.84.2"
+    escape-string-regexp "^4.0.0"
+    silent-error "^1.1.1"
+    uuid "^8.3.2"
+    vscode-languageserver "^8.0.1"
+    vscode-languageserver-textdocument "^1.0.5"
+    vscode-uri "^3.0.2"
+    yargs "^17.5.1"
+
+"@glint/environment-ember-loose@^1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@glint/environment-ember-loose/-/environment-ember-loose-1.0.0-beta.2.tgz#a189f7454a8404b5a5062c3bef554cf1043bfeff"
+  integrity sha512-WIsccams5kKvv8ECXQgrT1iySYYXWa+k5B4+1HFowr51ojkizFYrG5skAjIKX/7+ChuqpSLCAPquEOAp24Zhhw==
+
+"@glint/template@^1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@glint/template/-/template-1.0.0-beta.2.tgz#ed13ca4f0e6c616579d9eb9c6b11eac49899c742"
+  integrity sha512-gaWiWAjvmgOTmHUqXt+fACINMSnOxKcPYEwb6A6DNYpCaKWxhxqIjIrQLdrumULLK9+MbxMrIa3Od05FcIDQFQ==
+
 "@handlebars/parser@~2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
@@ -12121,6 +12145,41 @@ vm2@^3.9.8:
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"
+
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
+
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
+  dependencies:
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
+
+vscode-languageserver-textdocument@^1.0.5:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz#9eae94509cbd945ea44bca8dcfe4bb0c15bb3ac0"
+  integrity sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==
+
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+
+vscode-languageserver@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
+  dependencies:
+    vscode-languageserver-protocol "3.17.2"
+
+vscode-uri@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.7.tgz#6d19fef387ee6b46c479e5fb00870e15e58c1eb8"
+  integrity sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

The last pull request out of a series of PRs that I will make for #387.

I hope that the series of pull requests can show others, introducing v2 addon format, TypeScript, and Glint can be easy when done in small steps. 🧡


## Notes

After a new version of `ember-welcome-page` is released, we may want to [update the Glint documentation](https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons#typing-your-dependencies). Currently, the documentation uses `ember-welcome-page` as an example to illustrate what an end-user of Glint could do when an addon doesn't provide its template registry.

<img width="600" alt="" src="https://user-images.githubusercontent.com/16869656/208664227-860ebd14-3a24-4310-90d2-858c24469a2d.png">


## References

- https://typed-ember.gitbook.io/glint/using-glint/ember
- https://github.com/embroider-build/addon-blueprint (when `--typescript` flag is passed, Glint will be added to the project)