### PR TITLE
Allowed release-it to push a tag only (and let CI publish the tag)

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,12 +6,13 @@
     "release": true,
     "tokenRef": "GITHUB_AUTH"
   },
-  "npm": false,
   "plugins": {
     "@release-it-plugins/lerna-changelog": {
       "infile": "CHANGELOG.md",
       "launchEditor": true
     },
-    "@release-it-plugins/workspaces": true
+    "@release-it-plugins/workspaces": {
+      "publish": false
+    }
   }
 }


### PR DESCRIPTION
## Description

In https://github.com/ember-cli/ember-welcome-page/pull/392/commits/433f29a57cf3544b7089e038a47722ff367eb330, I incorrectly updated `.release-it.json` based on a code sample under https://github.com/release-it-plugins/workspaces#usage.

```json
{
  "release-it": {
    "plugins": {
      "@release-it-plugins/workspaces": true
    },
    "npm": false
  }
}
```

In this repo, the CI is responsible for publishing a tag to `npm`. We need to [tell `@release-it-plugins/workspaces` to push a tag only](https://github.com/release-it-plugins/workspaces#publish) (and not publish it).

```json
{
  "release-it": {
    "plugins": {
      "@release-it-plugins/workspaces": {
        "publish": false
      }
    }
  }
}
```