### PR TITLE
Updated release-it configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,10 @@ jobs:
 
       - name: Run auto-dist-tag
         run: npx auto-dist-tag@1 --write
+        working-directory: ember-welcome-page
 
       - name: Publish
         run: npm publish
+        working-directory: ember-welcome-page
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,21 @@
       "launchEditor": true
     },
     "@release-it-plugins/workspaces": {
-      "publish": false
+      "publish": false,
+      "workspaces": [
+        "ember-welcome-page"
+      ],
+      "additionalManifests": {
+        "dependencyUpdates": [
+          "package.json",
+          "test-app/package.json"
+        ],
+        "versionUpdates": [
+          "package.json",
+          "test-app/package.json"
+        ]
+      }
     }
-  }
+  },
+  "npm": false
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,7 +50,7 @@ yarn install
 * And last (but not least 😁) do your release.
 
 ```sh
-npx release-it
+yarn release
 ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
     "prepare": "yarn build",
+    "release": "release-it",
     "start": "concurrently \"npm:start:*\" --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-welcome-page run start",
     "start:test-app": "yarn workspace test-app run start",


### PR DESCRIPTION
A new attempt to fix how `release-it` and GitHub Actions, together, helps us publish a tag.


## References

I looked at a few [v2 addons that configured `@release-it-plugins/workspaces`](https://emberobserver.com/code-search?codeQuery=%22%40release-it-plugins%2Fworkspaces%22%3A%20%7B&sort=updated&sortAscending=false):

- https://github.com/miguelcobain/ember-css-transitions/blob/v4.3.2/package.json#L30-L66
- https://github.com/ember-modifier/ember-modifier/blob/v4.0.0/package.json#L30-L63
- https://github.com/mrloop/ember-metrics-simple-analytics/blob/v0.0.2/package.json#L42-L63
- https://github.com/tracked-tools/tracked-built-ins/blob/v3.2.0/package.json#L26-L57